### PR TITLE
Fixed Cloning Vats' Tooltip

### DIFF
--- a/rules/structures.yaml
+++ b/rules/structures.yaml
@@ -847,7 +847,7 @@ naclon:
 	Valued:
 		Cost: 2500
 	Tooltip:
-		Name: Cloning Vat
+		Name: Cloning Vats
 		Description: Clones most trained infantry.
 	Building:
 		Footprint: xx xx


### PR DESCRIPTION
Changed the Tooltip to be properly named as "Cloning Vats" and not "Cloning Vat".