### PR TITLE
Added support for RA2.mix

### DIFF
--- a/mod.yaml
+++ b/mod.yaml
@@ -22,6 +22,9 @@ MapFolders:
 	~^maps/ra2: User
 
 Packages:
+	~ra2.mix:CRC32
+	~language.mix:CRC32
+	~multi.mix:CRC32
 	audio.mix:CRC32
 	cache.mix:CRC32
 	cameo.mix:CRC32

--- a/mod.yaml
+++ b/mod.yaml
@@ -34,16 +34,16 @@ Packages:
 	isosnow.mix:CRC32
 	isotemp.mix:CRC32
 	isourb.mix:CRC32
-	load.mix:CRC32
+	~load.mix:CRC32
 	local.mix:CRC32
-	neutral.mix:CRC32
+	~neutral.mix:CRC32
 	sidec01.mix:CRC32
 	sidec02.mix:CRC32
 	sno.mix:CRC32
 	snow.mix:CRC32
 	tem.mix:CRC32
 	temperat.mix:CRC32
-	theme.mix:CRC32
+	~theme.mix:CRC32
 	urb.mix:CRC32
 	urban.mix:CRC32
 	audio.bag:CRC32


### PR DESCRIPTION
This is useful when using the assets from the official multi-player setup download http://xwis.net/downloads/Red-Alert-2-Multiplayer.exe found at http://xwis.net/forums/index.php/topic/177134-downloads/