### PR TITLE
RA2 - Added Bus, Automobile and Pickup Truck

### DIFF
--- a/audio/voices.yaml
+++ b/audio/voices.yaml
@@ -311,6 +311,7 @@ CarVoice:
 	DefaultVariant: .wav
 	Voices:
 		Select: gcarsela
+		Move: gcarsela
 		Burned: ienadia #gotta put something as temp else game crashes
 
 ChimpanzeeVoice:

--- a/rules/civilian-vehicles.yaml
+++ b/rules/civilian-vehicles.yaml
@@ -1,0 +1,81 @@
+bus:
+	Inherits: ^Vehicle
+	Valued:
+		Cost: 800
+	Tooltip:
+		Name: School Bus
+	Buildable:
+		Queue: Vehicle
+		BuildPaletteOrder: 300
+		Prerequisites: ~disabled
+	Mobile:
+		ROT: 5
+		Speed: 113
+	Health:
+		HP: 100
+	Armor:
+		Type: Light
+	RevealsShroud:
+		Range: 5c0
+	Cargo:
+		Types: Infantry
+		MaxWeight: 20
+		PipCount: 5
+	RenderSprites:
+	Selectable:
+		Bounds: 64, 52, 0, -6
+		Voice: CarVoice
+	RenderVoxels:
+	WithVoxelBody:
+
+pick:
+	Inherits: ^Vehicle
+	Valued:
+		Cost: 800
+	Tooltip:
+		Name: Pickup Truck
+	Buildable:
+		Queue: Vehicle
+		BuildPaletteOrder: 300
+		Prerequisites: ~disabled
+	Mobile:
+		ROT: 5
+		Speed: 113
+	Health:
+		HP: 100
+	Armor:
+		Type: Light
+	RevealsShroud:
+		Range: 5c0
+	RenderSprites:
+	Selectable:
+		Bounds: 64, 52, 0, -6
+		Voice: CarVoice
+	RenderVoxels:
+	WithVoxelBody:
+
+car:
+	Inherits: ^Vehicle
+	Valued:
+		Cost: 800
+	Tooltip:
+		Name: Automobile
+	Buildable:
+		Queue: Vehicle
+		BuildPaletteOrder: 300
+		Prerequisites: ~disabled
+	Mobile:
+		ROT: 5
+		Speed: 113
+	Health:
+		HP: 100
+	Armor:
+		Type: Light
+	RevealsShroud:
+		Range: 5c0
+	RenderSprites:
+	Selectable:
+		Bounds: 64, 52, 0, -6
+		Voice: CarVoice
+	RenderVoxels:
+	WithVoxelBody:


### PR DESCRIPTION
Not tried yet. Copy-Pasted from ts. Only removed cargo trait from Car and Pick and made them unable to build without devloper chats.