### PR TITLE
Decoupled fences and sandbags into a new CrushClass

### DIFF
--- a/ra2/rules/allied-vehicles.yaml
+++ b/ra2/rules/allied-vehicles.yaml
@@ -18,7 +18,7 @@ amcv:
 	Mobile:
 		Speed: 80
 		ROT: 5
-		Crushes: wall, crate, infantry
+		Crushes: fence, crate, infantry
 	RevealsShroud:
 		Range: 4c0
 	MustBeDestroyed:
@@ -91,7 +91,7 @@ mtnk:
 	Mobile:
 		Speed: 90
 		ROT: 5
-		Crushes: wall, crate, infantry
+		Crushes: fence, crate, infantry
 	Health:
 		HP: 300
 	Armor:
@@ -137,7 +137,7 @@ tnkd:
 	Mobile:
 		Speed: 70
 		ROT: 5
-		Crushes: wall, crate, infantry
+		Crushes: fence, crate, infantry
 	Health:
 		HP: 400
 	Armor:

--- a/ra2/rules/civilian-structures.yaml
+++ b/ra2/rules/civilian-structures.yaml
@@ -12,6 +12,8 @@ cafncb:
 		HP: 100
 	Armor:
 		Type: Wood
+	Crushable:
+		CrushClasses: fence
 
 cafncw:
 	Inherits: ^Wall
@@ -27,6 +29,8 @@ cafncw:
 		HP: 100
 	Armor:
 		Type: Wood
+	Crushable:
+		CrushClasses: fence
 
 gasand:
 	Inherits: ^Wall
@@ -42,6 +46,8 @@ gasand:
 		HP: 100
 	Armor:
 		Type: Wood
+	Crushable:
+		CrushClasses: fence
 
 cawash01:
 	Inherits: ^CivBuilding

--- a/ra2/rules/defaults.yaml
+++ b/ra2/rules/defaults.yaml
@@ -286,7 +286,7 @@
 	Inherits@2: ^GainsExperience
 	#Inherits@3: ^IronCurtainable
 	Mobile:
-		Crushes: crate, wall
+		Crushes: crate
 		TerrainSpeeds:
 			Clear: 100
 			Rough: 100

--- a/ra2/rules/soviet-vehicles.yaml
+++ b/ra2/rules/soviet-vehicles.yaml
@@ -19,7 +19,7 @@ smcv:
 		Speed: 85
 		ROT: 8
 		WaitAverage: 0
-		Crushes: wall, crate, infantry
+		Crushes: fence, crate, infantry
 	RevealsShroud:
 		Range: 4c0
 	MustBeDestroyed:
@@ -154,7 +154,7 @@ htnk:
 	Mobile:
 		Speed: 75
 		ROT: 5
-		Crushes: wall, crate, infantry
+		Crushes: fence, crate, infantry
 	Health:
 		HP: 400
 	Armor:
@@ -201,7 +201,7 @@ apoc:
 	Mobile:
 		Speed: 45
 		ROT: 5
-		Crushes: wall, crate, infantry
+		Crushes: fence, crate, infantry
 	Health:
 		HP: 800
 	Armor:
@@ -257,7 +257,7 @@ dtruck:
 		Speed: 85 # TODO
 		ROT: 8
 		WaitAverage: 0
-		Crushes: wall, crate, infantry
+		Crushes: fence, crate, infantry
 	RevealsShroud:
 		Range: 4c0
 	Explodes:


### PR DESCRIPTION
Wallcrushing wasn't possible in RA2 - such happened only in YR by the Battle Fortress.