### PR TITLE
Fix: Tesla Reactor provided 150 power in RA2, not 100.

### DIFF
--- a/ra2/rules/soviet-structures.yaml
+++ b/ra2/rules/soviet-structures.yaml
@@ -66,7 +66,7 @@ napowr:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	Power:
-		Amount: 100
+		Amount: 150
 	ScalePowerWithHealth:
 	SoundOnDamageTransition:
 		DestroyedSounds: bpowdiea.wav, bpowdieb.wav


### PR DESCRIPTION
See https://github.com/Phrohdoh/oramod-ra2/blob/master/extra-files/rules.ini#L8936